### PR TITLE
Add optional support for installing extension pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ```puppet
 include virtualbox
+include virtualbox::extensions
 ```
 
 ## Required Puppet Modules

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,3 +5,29 @@ class virtualbox {
   }
 }
 
+class virtualbox::extensions {
+  virtualbox::extension { 'extpack':
+    source   => 'http://download.virtualbox.org/virtualbox/4.2.10/Oracle_VM_VirtualBox_Extension_Pack-4.2.10-84104.vbox-extpack',
+    creates  => '/Applications/VirtualBox.app/Contents/MacOS/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack/ExtPack.xml',
+    require  => Package['VirtualBox-4.2.10']
+  }
+}
+
+define virtualbox::extension($source, $creates) {
+  $clean_source = strip($source)
+  $basename = inline_template('<%= File.basename(clean_source) %>')
+
+  Exec {
+    creates => $creates
+  }
+
+  exec {
+    "extension-download-${name}":
+      command => "/usr/bin/curl -L ${clean_source} > '/tmp/$basename'",
+      notify  => Exec["extension-install-${name}"];
+    "extension-install-${name}":
+      command     => "VBoxManage extpack install '/tmp/$basename'",
+      user        => 'root',
+      require     => Exec["extension-download-${name}"];
+  }
+}


### PR DESCRIPTION
This builds on #4, adding support for installing the extension pack if you add `include virtualbox::extensions` to your config
