### PR TITLE
Update VirtualBox to 4.2.16

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 class virtualbox {
   package { 'VirtualBox':
     provider => 'pkgdmg',
-    source   => 'http://download.virtualbox.org/virtualbox/4.2.14/VirtualBox-4.2.14-86644-OSX.dmg'
+    source   => 'http://download.virtualbox.org/virtualbox/4.2.16/VirtualBox-4.2.16-86992-OSX.dmg'
   }
 }
 

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'virtualbox' do
   it do
     should contain_package('VirtualBox').with({
-      :source   => 'http://download.virtualbox.org/virtualbox/4.2.14/VirtualBox-4.2.14-86644-OSX.dmg',
+      :source   => 'http://download.virtualbox.org/virtualbox/4.2.16/VirtualBox-4.2.16-86992-OSX.dmg',
       :provider => 'pkgdmg'
     })
   end


### PR DESCRIPTION
Since version 4.2.14 does not work well with vagrant (https://github.com/mitchellh/vagrant/issues/1847), this PR avoid new users to fall in this problem.
