### PR TITLE
Adds onlyif attribute to 'Kill Virtual Box Processes'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,10 +6,9 @@
 class virtualbox {
 
   exec { 'Kill Virtual Box Processes':
-    command => 'pkill "VBoxXPCOMIPCD" || true && pkill "VBoxSVC" || true && pkill "VBoxHeadless" || true',
-    path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-    #returns => [0,1],
-    #refreshonly => true,
+    command      => 'pkill "VBoxXPCOMIPCD" || true && pkill "VBoxSVC" || true && pkill "VBoxHeadless" || true',
+    path         => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    onlyif       => 'ps aux | grep "VBoxXPCOMIPCD\|VBoxSVC\|VBoxHeadless" | grep -v "grep"'
   }
 
   package { 'VirtualBox-4.3.0-89960':

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -8,5 +8,11 @@ describe 'virtualbox' do
       :provider => 'pkgdmg',
       :require  => 'Exec[Kill Virtual Box Processes]',
     })
+
+    should contain_exec('Kill Virtual Box Processes').with({
+      :command      => 'pkill "VBoxXPCOMIPCD" || true && pkill "VBoxSVC" || true && pkill "VBoxHeadless" || true',
+      :path         => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+      :onlyif       => 'ps aux | grep "VBoxXPCOMIPCD\|VBoxSVC\|VBoxHeadless" | grep -v "grep"'
+    })
   end
 end


### PR DESCRIPTION
This prevents the "kill processes" exec from running and the resulting notice from printing every run by only triggering the kill command when necessary.
