### PR TITLE
Update virtualbox version to release 4.3.20

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,8 @@
 #
 #   include virtualbox
 class virtualbox (
-  $version = '4.3.14',
-  $patch_level = '95030'
+  $version = '4.3.20',
+  $patch_level = '96996'
 ) {
 
   exec { 'Kill Virtual Box Processes':

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -9,9 +9,9 @@ describe 'virtualbox' do
     })
   end
   it do
-    should contain_package('VirtualBox-4.3.14-95030').with({
+    should contain_package('VirtualBox-4.3.20-96996').with({
       :ensure   => 'installed',
-      :source   => 'http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-OSX.dmg',
+      :source   => 'http://download.virtualbox.org/virtualbox/4.3.20/VirtualBox-4.3.20-96996-OSX.dmg',
       :provider => 'pkgdmg',
       :require  => 'Exec[Kill Virtual Box Processes]',
     })


### PR DESCRIPTION
## Overview

I'm new to puppet and boxen, but, what I wanted to do was use boxen to get virtualbox.. but get a more recent version of virtual box than what's presently supported by boxen/puppet-virtualbox in tag 1.0.13.

So-- like the other open pull requests before it-- this pull request changes puppet source and a spec to grab version 4.3.20 as described in the [virtualbox.org Changelog](https://www.virtualbox.org/wiki/Changelog).
## Next?

It's possible that this gets merged in, or it's possible that the maintainers of boxen/puppet-virtualbox are super-happy using the version they've got now, and so, this won't get merged in.

But-- if you're reading this and you'd like to use these changes, they exist over at jedcn/puppet-virtualbox and are tagged at 1.0.14: https://github.com/jedcn/puppet-virtualbox/tree/1.0.14.

And so.. what worked for me was to modify my `Puppetfile` and add the following lines to it:

``` ruby
github "virtualbox", "1.0.14", :repo => "jedcn/puppet-virtualbox"
```

And then run boxen. I hope it works for you, too.
## Details

Here are the explicit changes to my fork of boxen/our-boxen (which I renamed to mac-config):

https://github.com/jedcn/mac-config/commit/f28beb9da7bb8132a42d68bfdd1c0a93e596589a
